### PR TITLE
Add count variable to IDiffResult

### DIFF
--- a/diff/diff.d.ts
+++ b/diff/diff.d.ts
@@ -6,6 +6,7 @@
 declare namespace JsDiff {
     interface IDiffResult {
         value: string;
+        count?: number;
         added?: boolean;
         removed?: boolean;
     }


### PR DESCRIPTION
case 2. Improvement to existing type definition.
- Adds `count` variable to the `IDiffResult`. This variable in the result of the diff functions denotes the number of objects (lines/chars/word) combined under the result.
